### PR TITLE
added logic to access different endpoint for empty searches

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -223,7 +223,7 @@ function ml_wpsearch_search_query($query, $params)
     
     // send to different endpoint with empty search
     if ( is_array( $new_params['options'] ) ) {
-        if ( empty( $query['search']['qtext'] ) ) {
+        if ( empty( $query['search']['qtext'] ) && !empty( $new_params['options'][1] ) ) {
             $new_params['options'] = $new_params['options'][1];
         } else {
             $new_params['options'] = $new_params['options'][0];

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -220,6 +220,15 @@ function ml_wpsearch_search_query($query, $params)
         'options' => $options['rest_config_option'],
         'transform' => $options['rest_transform'],
     )));
+    
+    // send to different endpoint with empty search
+    if ( is_array( $new_params['options'] ) ) {
+        if ( empty( $query['search']['qtext'] ) ) {
+            $new_params['options'] = $new_params['options'][1];
+        } else {
+            $new_params['options'] = $new_params['options'][0];
+        }
+    }
 
     $new_query = apply_filters('ml_wpsearch_search_query_value', $new_query, $params);
 


### PR DESCRIPTION
Empty searches are better handled with a separate search endpoint. In order to use this, the endpoint name (previously sent as a string) can now be sent as an array of strings (2 max). When the search box is empty, the second name in the array is used, which sends the data to another endpoint.